### PR TITLE
Add RemoveListener for root emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Explore [these questions](https://github.com/kataras/go-events/issues?go-events=
 Versioning
 ------------
 
-Current: v0.0.2
+Current: v0.0.3
 
 Read more about Semantic Versioning 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Explore [these questions](https://github.com/kataras/go-events/issues?go-events=
 Versioning
 ------------
 
-Current: v0.0.3
+Current: v0.1.0
 
 Read more about Semantic Versioning 2.0.0
 

--- a/events.go
+++ b/events.go
@@ -3,8 +3,8 @@ package events
 
 import (
 	"log"
-	"sync"
 	"reflect"
+	"sync"
 )
 
 const (
@@ -321,6 +321,10 @@ func (e *emmiter) RemoveAllListeners(evt EventName) bool {
 }
 
 // RemoveListener removes the specified listener from the listener array for the event named eventName.
+func RemoveListener(evt EventName, listener Listener) bool {
+	return defaultEmmiter.RemoveListener(evt, listener)
+}
+
 func (e *emmiter) RemoveListener(evt EventName, listener Listener) bool {
 	if e.evtListeners == nil {
 		return false
@@ -333,7 +337,7 @@ func (e *emmiter) RemoveListener(evt EventName, listener Listener) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	listeners := e.evtListeners[evt];
+	listeners := e.evtListeners[evt]
 
 	if listeners == nil {
 		return false
@@ -351,10 +355,10 @@ func (e *emmiter) RemoveListener(evt EventName, listener Listener) bool {
 	}
 
 	if idx < 0 {
-		return  false
+		return false
 	}
 
-	var modifiedListeners []Listener = nil
+	var modifiedListeners []Listener
 
 	if len(listeners) > 1 {
 		modifiedListeners = append(listeners[:idx], listeners[idx+1:]...)

--- a/events.go
+++ b/events.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Version current version number
-	Version = "0.0.3"
+	Version = "0.1.0"
 	// DefaultMaxListeners is the number of max listeners per event
 	// default EventEmitters will print a warning if more than x listeners are
 	// added to it. This is a useful default which helps finding memory leaks.

--- a/events.go
+++ b/events.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Version current version number
-	Version = "0.0.2"
+	Version = "0.0.3"
 	// DefaultMaxListeners is the number of max listeners per event
 	// default EventEmitters will print a warning if more than x listeners are
 	// added to it. This is a useful default which helps finding memory leaks.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/vedicium/go-events
+
+go 1.16


### PR DESCRIPTION
This'll add the 'RemoveListener' function for the root emitter.
You can remove listeners when you create a new emitter, but this library supports an emitter out of the box, I like to call it the 'root' emitter.

There was no way to remove listeners on that emitter in a simple way. And most functions have a wrapper foor the root emitter. So I've created one for the RemoveListener.