### PR TITLE
Fix wrong payload for Once handler.

### DIFF
--- a/events.go
+++ b/events.go
@@ -266,7 +266,7 @@ type oneTimelistener struct {
 
 func (l *oneTimelistener) execute(vals ...interface{}) {
 	if atomic.CompareAndSwapInt32(&l.fired, 0, 1) {
-		l.listener(vals)
+		l.listener(vals...)
 		go l.emitter.RemoveListener(l.evt, l.executeRef)
 	}
 }

--- a/events_test.go
+++ b/events_test.go
@@ -103,6 +103,9 @@ func TestEventsOnce(t *testing.T) {
 		if count > 0 {
 			t.Fatalf("Once's listener fired more than one time! count: %d", count)
 		}
+		if payload[0] != "foo" {
+			t.Fatalf("Once's listener payload is incorrect: %+v", payload)
+		}
 		count++
 	})
 
@@ -115,7 +118,7 @@ func TestEventsOnce(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		Emit("my_event")
+		Emit("my_event", "foo")
 	}
 
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
To Once's listeners, there are all arguments passed as array in first argument, what is obviously wrong.

Although this issue was introduced in 6e0eeb3dcfa58085193392580e9db163f08c5304, it was never part of a release until recently.

Please after merging this fix also create new tag so that it can be properly distributed using golang dependencies.